### PR TITLE
2020temaslapp

### DIFF
--- a/src/components/AboutUsDefault.vue
+++ b/src/components/AboutUsDefault.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="contents">
     <h1>Om F-spexet</h1>
+
+    <hr>
+
     <p
       class="bparagraph"
     >Under våren och hösten kommer F-spexet framföra 2020 års fantastiska uppsättning. Allt om denna finns att läsa om här.</p>

--- a/src/components/Contact.vue
+++ b/src/components/Contact.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="contents">
     <h1>Kontakta oss</h1>
+
+    <hr>
+
     <p> Nu är det ju så att det kan finnas några som vill ha tag i spexarna.
     Ett alternativ är ju då att ställa sig på lämpligt ställe i fysikhuset och ropa,
     men du har nog mer framgång med någon av våra mailadresser.

--- a/src/components/Groups.vue
+++ b/src/components/Groups.vue
@@ -3,35 +3,45 @@
     <h1>Grupper i F-spexet</h1>
     <p
       class="bparagraph"
-    >Vill du lära dig vad folk gör i f-spexet? Funderar du kanske på att vara med i nästa spex? Nedan kan ni läsa om de olika posterna och vad de sysslar med under spex-året.</p>
+    >Vill du lära dig vad folk gör i f-spexet? Funderar du kanske på att vara med i
+    nästa spex? Nedan kan ni läsa om de olika posterna och vad de sysslar med under spex-året.</p>
     <hr>
     <h2>Styret</h2>
     <p>
       Styret är de som ansvarar för att det överhuvudtaget blir ett F-spex.
-      De sitter i otaliga lunchmöten för att planera, boka, styra, och se till att spexet fungerar och är roligt.
+      De sitter i otaliga lunchmöten för att planera, boka, styra, och se till att
+      spexet fungerar och är roligt.
     </p>
     <div id="styret">
       <h3>Ordförande</h3>
-      <p>För att hålla koll på allt och alla, även styret, krävs någon på toppen. Ordförande (också kallad Tant) leder styrets arbete.</p>
+      <p>För att hålla koll på allt och alla, även styret, krävs någon på toppen.
+        Ordförande (även kallad <it>Tant</it>) leder styrets arbete och är F-spexets
+        ansikte utåt.</p>
 
       <h3>Förman</h3>
-      <p>Förmannen är spexets arbetsledare som ser till att varje grupp arbetar och gör det de ska. Förmannen har genom sina mail-superkrafter kontakt med varje enskild spexare och löser diverse problem som kan dyka upp.</p>
+      <p>Förmannen, som också går vid namnet <it>Fröken</it>, är spexets arbetsledare
+        som ser till att varje grupp arbetar och gör det de ska. Förmannen har genom
+        sina mail-superkrafter kontakt med varje enskild spexare och löser diverse
+        problem som kan dyka upp.</p>
 
       <h3>Kassör</h3>
-      <p>Kassören har ansvar för spexets ekonomi och uppgifterna utgörs framförallt av att sköta bokföringen, skriva ihop strecklistor och ansvara för biljettförsäljningen.</p>
+      <p>Kassören, gemenligen <it>Fru</it> har ansvar för spexets ekonomi och uppgifterna
+        utgörs framförallt av att sköta bokföringen, skriva ihop strecklistor och ansvara
+        för biljettförsäljningen.</p>
 
       <h3>Ledamot</h3>
-      <p>Ledamöterna är styrelsens råa arbetskraft. För alla stora och små uppgifter som inte täcks av de övriga posterna finns det alltid en ledamot som kan ställa upp och föra spexets arbete framåt.</p>
+      <p>De övriga posterna i Styret är ledamöter. För alla stora och små uppgifter som
+        inte täcks av de andra posterna finns det alltid en ledamot som kan ställa upp
+        och föra spexets arbete framåt.</p>
     </div>
     <br>
     <hr>
     <h3>Manusförfattare</h3>
     <p>En av de mest essentiella ingredienserna för ett bra spex är ett bra manus.</p>
     <p>
-      Manusgruppen är den viktiga grupp, som innan andra spexare ens har kommit
-      att tänka på nästa års spex, redan har bestämt tema, synopsis, karaktärer,
-      repliker, nödvändig rekvisita, lagt förslag på kupletter och en massa annat.
-      Detta tar mycket mer tid än man tror, men det är också mycket givande.
+      Manusgruppen är den grupp som, innan andra spexare ens har kommit att tänka
+      på nästa års spex, redan har bestämt tema, synopsis, karaktärer, repliker,
+      nödvändig rekvisita, lagt förslag på kupletter och en massa annat.
     </p>
     <p>
       Efter manuset är färdigt blir man inte utkastad utan kan söka vad man vill
@@ -39,92 +49,121 @@
     </p>
     <hr>
 
-    <h3>Ensemblen</h3>
+    <h3>Skådespelare</h3>
     <p>
-      Också en relativt viktig grupp i ett F-Spex. Ensemblens uppgift i spexet är
-      att stå på scen och framföra det spex som manusgruppen har skrivit, regissören
-      regisserat och publiken bett om.
+      Gemenligen kallade Ensemblen. Skådespelarnas uppgift i spexet är att stå på scen
+      och framföra det spex som manusgruppen har skrivit, regissören regisserat och
+      publiken bett om. Den som blir invald som Skådespelare får en roll tilldelad sig,
+      och sätter därefter igång med att lära sig manuset, sångtexterna och dansstegen
+      utantill. De övar också på improvisation inför inropen. Skådespelarna repar under
+      ledning av Regissören, både på egen hand och tillsammans med Orkestern.
     </p>
     <hr>
 
     <h3>Orkestern</h3>
     <p>
-      Det är Orkestern som förgyller föreställningarna med fantastisk live-musik, en
-      utav de viktigaste grupperna, och en utav de absolut roligaste att medverka i.
+      Det är Orkestern som förgyller föreställningarna med fantastisk live-musik.
+      Förutom att arrangera och spela upp kupletter, spelar Orkestern också ett aktintro
+      till varje akt. En bra färdighet i Orkestern är därför, förutom att så klart kunna
+      spela sitt instrument, att arrangera musik.
     </p>
     <hr>
 
     <h3>Producent</h3>
     <p>
-      Producenten för F-spexet väljer i mångt och mycket sin egen stil och den ene Producenten är
-      inte den andre lik. Producentens uppgifter går bland annat ut på att välja vilka låtar som ska arras
-      och vilken rekvisita som ska byggas.
+      Producenten ser till att spexet har en enhetlig konstnärlig vision, och har på så
+      sätt ett finger med i såväl rekvisita som kupletter, och samordnar mellan grupperna
+      överlag. Producenten väljer i mångt och mycket sin egen stil och den ene Producenten
+      är inte den andre lik.
     </p>
     <hr>
 
     <h3>Regissör</h3>
     <p>
-      Regissörens uppgift är att likt Bergman i basker gorma och gnälla på ensemblen så att de
-      agerar bra. Som regissör är du också ansvarig för att det blir rep lagom ofta, både för
-      ensemblen själva och tillsamman med orkestern.
+      Regissörens uppgift är att leda Skådespelarnas rep, samt gnälla och tjata på Skådespelarna
+      så att de gör rätt saker vid rätt tillfälle under dessa rep (naturligtvis med en grund i
+      årets manus). Som Regissör är man också ansvarig för att det blir rep, både för Skådespelarna
+      själva och tillsammans med Orkestern.
     </p>
     <hr>
 
     <h3>Mat</h3>
     <p>
-      Mat har som huvudsaklig uppgift att se till att det serveras en trerättersmiddag under
-      föreställningarna. Detta innebär i realiteten att planera inköp, handla samt komma på nya
-      rätter för att kunna anpassa maten till olika allergier och matpreferenser.
+      Matgruppen har som huvudsaklig uppgift att se till att det serveras en trerätters middag
+      under föreställningarna. Detta innebär i realiteten att planera inköp, handla samt anpassa
+      maten till olika allergier och matpreferenser. Förutom föreställningarna står Matgruppen
+      även för maten på sittningar och dylikt inom spexet.
     </p>
     <hr>
 
     <h3>Ljud och ljus (LoL)</h3>
     <p>
-      LOL har till uppgift att bestämma vilken typ av utrustning årets spex behöver samt
-      rigga densamma innan varje föreställning, samt under föreställningarna sköta reglagen för att de som
-      ska synas syns och de som ska höras hörs.
+      LoL har till uppgift att bestämma vilken typ av ljud- och ljusutrustning årets spex behöver,
+      rigga densamma innan varje föreställning, samt under föreställningarna sköta reglagen så
+      att de som ska synas syns och de som ska höras hörs.
     </p>
     <hr>
 
-    <h3>Scengruppen</h3>
+    <h3>Scen</h3>
     <p>
-      Scengruppens ansvar är att se till så att det existerar en scen att spela upp spexet på, kulisser
-      att spela upp spexet framför (och stundtals bakom), samt rekvisita att spela upp spexet med.
-      Detta ska givetvis försöka göras på ett sådant sätt att publiken inte inser att scengruppen ens
-      existerar.
+      Varje spexmanus kräver en mängd dekor, kulisser och rekvisita. Det kan vara allt från böcker
+      eller papper till nycklar och kanoner, lönndörrar, och diverse sorters maskiner. Scengruppen
+      behöver använda sin uppfinningsrikedom för att snickra, pyssla, bygga, och måla allt detta.
     </p>
     <hr>
 
     <h3>Kostym</h3>
     <p>
-      Det är Kostym som syr alla fina kläder på scen. Deras ansvar är
-      att leta igenom manus och bestämma hur Ensemblen skall se ut, lista ut
-      hur detta kan sys, sy det och skälla när Ensemblen har sönder sagda kläder.
+      Det är Kostym som syr alla fina kläder på scen. Deras ansvar är att leta igenom manuset
+      och bestämma hur Skådespelarna skall se ut, lista ut hur detta kan sys, sy det, och skälla
+      när Skådespelarna har sönder sagda kläder. Ibland syr även Kostym viss tygbaserad rekvisita,
+      exempelvis kuddar och draperier.
     </p>
     <hr>
 
-    <h3>Sminköser</h3>
+    <h3>Smink</h3>
     <p>
-      Detta är gruppen som ger spexare färg och gör så att ensemblen ser ut som sina karaktärer med hjälp av
-      peruker, smink, träben, huggtänder och dylikt.
+      Detta är gruppen som ger spexare färg och gör så att ensemblen ser ut som sina karaktärer
+      med hjälp av peruker, smink, träben, huggtänder och dylikt.
     </p>
     <hr>
 
     <h3>Media</h3>
     <p>
-      Media-gruppen ser till att spexet syns och hörs och ansvarar för all reklam så som biljetter och affischer.
-      Vi ser helt enkelt till att folk vet allt om spexets föreställningar, aspning och dylikt.
+      Mediagruppen ser till att folk vet vad spexet håller på med och ansvarar för all
+      reklam så som biljetter och affischer. De ser till att folk vet allt om spexets
+      föreställningar, aspning och dylikt, och spelar in minst en hel föreställning som
+      kan ses av framtida spexare. De ansvarar även för spännande saker så som hemsidan du
+      just nu läser detta på.
     </p>
     <p>
-      Av historiska skäl är det bra och roligt att dokumentera, Mediagruppen förväntas göra detta genom valfritt medium,
-      till exempelvis fotografier.
+      Av historiska skäl är det bra och roligt att dokumentera, Mediagruppen förväntas göra
+      detta genom valfritt medium, till exempel fotografier.
     </p>
     <hr>
 
     <h3>MåBra</h3>
     <p>
-      MåBra är gruppen som mutar alla med kakor, bullar och godis för att se till
-      att alla har så roligt som möjligt och gör sitt bästa.
+      MåBra har till uppgift att övriga spexare (och de själva) mår bra, har det så roligt
+      som möjligt och gör sitt bästa. För att uppnå sitt mål brukar de använda sig av ett
+      hemligt vapen gemenligen kallat ”kakor”. MåBra-gruppen har ett antal fasta arbetsuppgifter:
+      de anordnar mysiga spexkvällar, sköter baren under föreställningarna, och fixar pizza och
+      liknande åt spexarna när spexet har jobbat hela dagen.
+    </p>
+
+    <h3>Kuplettsamordnare</h3>
+    <p>
+      Kuplettsamordnare ansvarar för att samordna kupletterna, alltså låtarna, i spexet. Detta
+      innefattar bland annat att se till att melodierna passar de som ska sjunga och spela, se
+      till att intresserade spexare skriver kupletterna, och att de blir färdiga i tid.
+    </p>
+    <hr>
+
+    <h3>Koreograf</h3>
+    <p>
+      Koreografen arbetar mycket med att komma på danser som Skådespelarna ska framföra,
+      och sedan lära Skådespelarna dessa danser. Detta innebär att ha extra mycket koll på
+      sångerna och melodierna, samt vara närvarande på Skådespelarnas rep lagom mycket.
     </p>
   </div>
 </template>

--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -26,18 +26,17 @@ export default {
 /*Normalize html and body elements,this style is just good to have*/
 @font-face {
   font-family: EB Garamond;
-  src: url(../assets/fonts/EBGaramond12-Regular.otf) format('opentype');
   font-style: normal;
+  src: url(../assets/fonts/EBGaramond12-Regular.otf) format('opentype');
 }
 @font-face {
   font-family: EB Garamond;
-  src: url(../assets/fonts/EBGaramond12-Italic.otf) format('opentype');
   font-style: italic;
+  src: url(../assets/fonts/EBGaramond12-Italic.otf) format('opentype');
 }
 @font-face {
-  font-family: EB Garamond;
+  font-family: EB Garamond SC;
   src: url(../assets/fonts/EBGaramondSC12-Regular.otf) format('opentype');
-  font-style: oblique;
 }
 @font-face {
   font-family: Josefin;
@@ -76,9 +75,7 @@ body {
   max-width: 700px;
 }
 
-h1{
-  color: white;
-}
+h1,
 h2,
 h3,
 h4,
@@ -92,28 +89,42 @@ ul {
 p {
   font-size: 20px;
   font-style: normal;
+  font-variant: normal;
+  margin-top: 15px;
+  margin-bottom: 15px;
+}
+
+h0 {
+  color: white;
+  font-family: Josefin, Futura, 'PakType Tehreer', sans;
+  font-size: 48px;
+  font-weight: bold;
+  font-style: normal;
+}
+
+h1 {
+  font-variant: small-caps;
+  font-size: 48px;
+  margin-bottom: 0px;
 }
 
 h2 {
   font-size: 32px;
-  font-style: oblique;
+  font-variant: small-caps;
+  margin-bottom: 10px;
 }
 
 h3 {
   font-size: 24px;
   font-style: italic;
+  margin-bottom: 10px;
 }
 
 h4 {
   font-size: 24px;
   font-style: italic;
-}
-
-div > h1 {
-  font-family: 'EB Garamond', 'Times New Roman', Times, serif;
-  font-weight: normal;
-  font-style: oblique;
-  font-size: 48px;
+  margin-top: 0px;
+  margin-bottom: 0px;
 }
 
 a {
@@ -124,10 +135,6 @@ a {
 
 li {
   font-size: 20px;
-}
-
-.smallcaps {
-  font-style: oblique;
 }
 
 .bparagraph {

--- a/src/components/MainFooter.vue
+++ b/src/components/MainFooter.vue
@@ -6,11 +6,13 @@
       <div class="content" id="plats">
         <h2>Var?</h2>
         <!-- <p>Sektionslokalen Focus,
-          <br>Kemivägen 11, 412 58 Göteborg
+          <br>Kemivägen 11,
+          <br>412 58 Göteborg
         </p>
           <a href="https://goo.gl/maps/MjCnfJkefUu6JHhR6">Google maps</a> -->
           <p>Kalle Glader,
-          <br>Hugo Grauers gata 4A, 411 33 Göteborg
+          <br>Hugo Grauers gata 4A,
+          <br>411 33 Göteborg
         </p>
           <a href="https://goo.gl/maps/vGRffRGxgRMErT4RA">Google maps</a>
       </div>
@@ -52,11 +54,6 @@ button a {
   color: black;
 }
 
-h1 {
-  font-family: 'EB Garamond', 'Times New Roman', Times, serif;
-  font-weight: normal;
-  font-style: oblique;
-}
 
 .content {
   border-radius: 30px;
@@ -75,7 +72,4 @@ p {
   margin-bottom: 00px;
 }
 
-a{
-  font-family: 'EB Garamond', 'Times New Roman', Times, serif;
-}
 </style>

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -2,19 +2,19 @@
   <header>
     <div id="top">
       <router-link class="toplink" to="/tickets">
-        <h1>BILJETTER</h1>
+        <h0>BILJETTER</h0>
       </router-link>
       <router-link class="toplink" to="/menu">
-        <h1>MENY</h1>
+        <h0>MENY</h0>
       </router-link>
       <router-link class="toplink" id="logo" to="/">
         <img id="logo-image" src="@/assets/logo_new.png" alt="F-spexet 2020">
       </router-link>
       <router-link class="toplink" to="/about-us">
-        <h1>OM OSS</h1>
+        <h0>OM OSS</h0>
       </router-link>
       <router-link class="toplink" to="/contact">
-        <h1>KONTAKT</h1>
+        <h0>KONTAKT</h0>
       </router-link>
     </div>
   </header>
@@ -25,12 +25,11 @@ header {
   width: max-content;
   background-color: black;
   margin: 5px auto;
-  font-family: Josefin, Futura, 'PakType Tehreer';
 }
 
-@media screen and (max-width: 800px) {
+@media screen and (max-width: 1350px) {
   header {
-    width: 100%;
+    width: 50px;
     height: 100%;
   }
   #top {
@@ -43,12 +42,13 @@ header {
     position: relative;
     order: 3;
     xflex: 1 1 30%;
-    flex-shrink: 5;
-    width: 1%;
+    flex-shrink: 0;
+    width: 500%;
+    text-align: center;
   }
   #logo:nth-child(3) {
     flex: 0 0 100%;
-    width: 1%;
+    width: 100%;
     order: 1;
     /* justify-self: auto; */
     }

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -7,23 +7,23 @@
 
       <p
         class="bparagraph"
-      >P&aring; v&aring;ra f&ouml;rest&auml;llningar serveras en full, trer&auml;tters middag.</p>
-      
-      <h3>F&ouml;rr&auml;tt</h3>
-      <h4>Potatis & purjol&ouml;ksſoppa</h4> 
-      <p>Vad bättre att påbörja kvällen med än en värmande soppa? En gräddig rikhet värdig 
-en kejsare ger den här enkla rätten mer karaktär än den redan har, och inspirerar 
+      >På våra föreställningar serveras en full, trerätters middag.</p>
+
+      <h3>Förrätt</h3>
+      <h4>Potatis &amp; purjolöksſoppa</h4>
+      <p>Vad bättre att påbörja kvällen med än en värmande soppa? En gräddig rikhet värdig
+en kejsare ger den här enkla rätten mer karaktär än den redan har, och inspirerar
 till vidare aptit för det som komma skall.</p>
 
-      <h3>Huvud&auml;tt</h3>
+      <h3>Huvudätt</h3>
       <h4>Kycklinggryta med paprika</h4>
-      <p>Efter en kejserlig välkomst, behövs ett jordnära emottagande. Denna kycklinggryta i 
-östeuropeisk anda viger samman de enkla frukterna från terra nostra i ett lyckligt giftermål 
+      <p>Efter en kejserlig välkomst, behövs ett jordnära emottagande. Denna kycklinggryta i
+östeuropeisk anda viger samman de enkla frukterna från terra nostra i ett lyckligt giftermål
 av kyckling och grönsaker.</p>
 
-      <h3>Efterr&auml;tt</h3>
-      <h4>P&auml;ronſmulpaj med vaniljſ&aring;s</h4>
-      <p>För att avsluta kvällen på fruktsamt vis erbjuds det närmsta uppnåeliga till ett 
+      <h3>Efterrätt</h3>
+      <h4>Päronſmulpaj med vaniljſäs</h4>
+      <p>För att avsluta kvällen på fruktsamt vis erbjuds det närmsta uppnåeliga till ett
 Magna Pirum &ndash; i pajform naturligtvis! Himmelskt god som den är, kommer denna stjärna till bakelse bara lämna en sak att önska: en uppfriskande vaniljsås!</p>
 
       <h2>Alternativ kost</h2>
@@ -66,7 +66,7 @@ h4 {
   font-feature-settings: "dlig", "hlig", "swsh", "cv04", "cv05";
 }
 h3 {
-  
+
   font-variant: small-caps;
 }
 </style>

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -16,13 +16,13 @@ en kejsare ger den här enkla rätten mer karaktär än den redan har, och inspi
 till vidare aptit för det som komma skall.</p>
 
       <h3>Huvudätt</h3>
-      <h4>Kycklinggryta med paprika</h4>
+      <h4>Kycklinggryta med blomkålsris</h4>
       <p>Efter en kejserlig välkomst, behövs ett jordnära emottagande. Denna kycklinggryta i
 östeuropeisk anda viger samman de enkla frukterna från terra nostra i ett lyckligt giftermål
 av kyckling och grönsaker.</p>
 
       <h3>Efterrätt</h3>
-      <h4>Päronſmulpaj med vaniljſäs</h4>
+      <h4>Päronſmulpaj med vaniljſås</h4>
       <p>För att avsluta kvällen på fruktsamt vis erbjuds det närmsta uppnåeliga till ett
 Magna Pirum &ndash; i pajform naturligtvis! Himmelskt god som den är, kommer denna stjärna till bakelse bara lämna en sak att önska: en uppfriskande vaniljsås!</p>
 

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -1,28 +1,50 @@
 <template>
   <div class="contents">
     <div id="meny">
-      <h1>Menyn</h1>
+      <center>
+      <h1>Meny</h1>
+      <hr>
+
       <p
         class="bparagraph"
-      >Ibland gillar man att veta vad man äter. Därför tänkte vi dela med oss av våran meny.</p>
+      >P&aring; v&aring;ra f&ouml;rest&auml;llningar serveras en full, trer&auml;tters middag.</p>
+      
+      <h3>F&ouml;rr&auml;tt</h3>
+      <h4>Potatis & purjol&ouml;ksſoppa</h4> 
+      <p>Vad bättre att påbörja kvällen med än en värmande soppa? En gräddig rikhet värdig 
+en kejsare ger den här enkla rätten mer karaktär än den redan har, och inspirerar 
+till vidare aptit för det som komma skall.</p>
 
-      <h3>Mat</h3>
-       <p>Exakt info bör vara tillgänglig nära början av Mars.</p>
+      <h3>Huvud&auml;tt</h3>
+      <h4>Kycklinggryta med paprika</h4>
+      <p>Efter en kejserlig välkomst, behövs ett jordnära emottagande. Denna kycklinggryta i 
+östeuropeisk anda viger samman de enkla frukterna från terra nostra i ett lyckligt giftermål 
+av kyckling och grönsaker.</p>
+
+      <h3>Efterr&auml;tt</h3>
+      <h4>P&auml;ronſmulpaj med vaniljſ&aring;s</h4>
+      <p>För att avsluta kvällen på fruktsamt vis erbjuds det närmsta uppnåeliga till ett 
+Magna Pirum &ndash; i pajform naturligtvis! Himmelskt god som den är, kommer denna stjärna till bakelse bara lämna en sak att önska: en uppfriskande vaniljsås!</p>
 
       <h2>Alternativ kost</h2>
         <p>
         Vi serverar självklart mat även om du behöver specialkost (vegetarisk,
         veganskt, glutenfritt etc.). Kom bara ihåg att ange det när du beställer
-        biljett. Om du vill veta spexifikt vad som för justeringar som görs kan du skicka
+        biljett. Om du vill veta spexifikt vad för justeringar som görs kan du skicka
         mail till <a href="mailto:mat@f-spexet.se"> mat@f-spexet.se</a>
         </p>
+      </center>
     </div>
 
     <hr>
 
-    <h2>Baren</h2>
+    <div id="drinks">
+      <center>
+      <h2>Dryckor</h2>
       <p>Utöver den inkluderade trerätters middagen har vi även en bar där man kan köpa alkoholfri dryck som läsk eller drinkar.</p>
       <p>Om du önskar dricka alkohol på våra föreställningar är du tvungen att ta med eget. Vi har ingen möjlighet till försäljning av alkohol.</p>
+      </center>
+    </div>
   </div>
 </template>
 
@@ -35,15 +57,16 @@ export default {
 </script>
 
 <style scoped>
-h1 {
-  margin-bottom: 10px;
+h3,
+h4 {
+  text-rendering: optimiseLegibility;
+  -ms-font-feature-settings: "dlig", "hlig", "swsh", "cv04", "cv05";
+  -webkit-font-feature-settings: "dlig", "hlig", "swsh", "cv04", "cv05";
+  -moz-font-feature-settings: "dlig", "hlig", "swsh", "cv04", "cv05";
+  font-feature-settings: "dlig", "hlig", "swsh", "cv04", "cv05";
 }
 h3 {
-  margin-top: 20px;
-  margin-bottom: 00px;
-}
-h3+p {
-  margin-top: 00px;
-  margin-bottom: 20px;
+  
+  font-variant: small-caps;
 }
 </style>

--- a/src/components/News.vue
+++ b/src/components/News.vue
@@ -5,7 +5,7 @@
       <h2>Spexets temasläppvisa</h2>
       <h3>Text av:Media</h3>
       <h3>Orginal melodi:Idas sommarvisa</h3>
-      
+
       <p>
 
       Du ska inte tro det blir spex snart <br>

--- a/src/components/News.vue
+++ b/src/components/News.vue
@@ -51,8 +51,9 @@
 
     <div id="news_temaslapp">
       <h2>F-spexet 2020 &mdash; Johannes Kepler</h2>
-      <p id="intro">
-        <i>eller Illustrerad Vetenskap</i>
+      <p>
+        <span style="font-family:EB Garamond SC">eller</span>
+        <span style="font-style:italic;font-feature-settings:'hlig'"> Illustrerad Vetenskap</span>
       </p>
       <p>
        Är er vardag trist och grå? Har ni alltid haft siktet inställt på stjärnorna men aldrig
@@ -60,7 +61,7 @@
        Kepler som alltid har något i kikaren, bokstavligen.
      </p><p>
        Vecka 13 framför vi 2020 års fantastiska spex, som tar oss till det Tysk-Romerska rikets
-       hov i Prag kring sekelskiftet år 1600. Vi följer den unge Johannes Kepler ska just träda in som lärling
+       hov i Prag kring sekelskiftet år 1600. Vi följer den unge Johannes Kepler som just ska träda in som lärling
        till hovastronomen Tycho Brahe, efter att ha nått prominens i Graz under sin mentor, Michael Mästlin.
      </p><h3>
        <router-link to="/tickets">Se föreställningsdatum och köp biljetter här!</router-link>


### PR DESCRIPTION
- Added this year's menu to /menu
- Temporarily fixed mobile (or any less-than-superwide aspect ratio) version
- Returned CSS to its proper, redundant and bloated state ("fixes" issues with mobile devices using incorrect font variants)
- Rotated background.png image to fit the site's vertically oblong nature
- Updated /about-us/groups with new descriptions matching those in the Program (taken from https://www.overleaf.com/read/krmvmnpvmcmn)